### PR TITLE
[Feature] Navigation 세팅 - 사용 예시 추가

### DIFF
--- a/app/src/main/java/com/teamyg/MainActivity.kt
+++ b/app/src/main/java/com/teamyg/MainActivity.kt
@@ -6,17 +6,31 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
+import com.teamyg.login.api.NavKeyLoginHome
+import com.teamyg.navigation.Navigator
 import com.teamyg.ui.theme.TeamYGTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var entryBuilders: Set<@JvmSuppressWildcards EntryProviderScope<NavKey>.(Navigator) -> Unit>
+
+    @Inject
+    lateinit var navigator: Navigator
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             TeamYGTheme {
                 MainRoute(
+                    navigator = navigator,
+                    entryBuilders = entryBuilders,
                     modifier = Modifier.fillMaxSize(),
                 )
             }

--- a/app/src/main/java/com/teamyg/MainRoute.kt
+++ b/app/src/main/java/com/teamyg/MainRoute.kt
@@ -19,11 +19,13 @@ fun MainRoute(
 ) {
     NavDisplay(
         entryDecorators = listOf(
-            // Add the default decorators for managing scenes and saving state
+            // NavEntry Lifecycle 동안 유효한 SaveableState 를 만드는 Decorator
             rememberSaveableStateHolderNavEntryDecorator(),
-            // Then add the view model store decorator
+            // NavEntry Lifecycle 동안 유효한 ViewModel 를 만드는 Decorator
             rememberViewModelStoreNavEntryDecorator(),
-            // Use EventBus For Get Returning Result
+            // NavEntry 범위마다 공통 ReturnEventBus 객체를 CompositionLocal 로 제공하는 Decorator
+            // Returning Result 를 위해 사용하는 EventBus 를 feature impl 모듈들의 Composable 에서
+            // LocalResultEventBus.current 로 가져올 수 있게 됨
             rememberResultEventBusNavEntryDecorator(),
         ),
         backStack = navigator.backStack,

--- a/app/src/main/java/com/teamyg/MainRoute.kt
+++ b/app/src/main/java/com/teamyg/MainRoute.kt
@@ -7,6 +7,7 @@ import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.runtime.result.rememberResultEventBusNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import com.teamyg.navigation.Navigator
 
@@ -22,6 +23,8 @@ fun MainRoute(
             rememberSaveableStateHolderNavEntryDecorator(),
             // Then add the view model store decorator
             rememberViewModelStoreNavEntryDecorator(),
+            // Use EventBus For Get Returning Result
+            rememberResultEventBusNavEntryDecorator(),
         ),
         backStack = navigator.backStack,
         onBack = navigator::onBack,

--- a/app/src/main/java/com/teamyg/MainRoute.kt
+++ b/app/src/main/java/com/teamyg/MainRoute.kt
@@ -1,13 +1,33 @@
 package com.teamyg
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.teamyg.feature.sample.UserScreen
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
+import com.teamyg.navigation.Navigator
 
 @Composable
-fun MainRoute(modifier: Modifier = Modifier) {
-    Box(modifier = modifier) {
-        UserScreen()
-    }
+fun MainRoute(
+    navigator: Navigator,
+    entryBuilders: Set<EntryProviderScope<NavKey>.(Navigator) -> Unit>,
+    modifier: Modifier = Modifier,
+) {
+    NavDisplay(
+        entryDecorators = listOf(
+            // Add the default decorators for managing scenes and saving state
+            rememberSaveableStateHolderNavEntryDecorator(),
+            // Then add the view model store decorator
+            rememberViewModelStoreNavEntryDecorator(),
+        ),
+        backStack = navigator.backStack,
+        onBack = navigator::onBack,
+        entryProvider = entryProvider {
+            entryBuilders.forEach { builder -> this.builder(navigator) }
+        },
+        modifier = modifier,
+    )
 }

--- a/core/navigation/src/main/java/com/teamyg/navigation/NavigationModule.kt
+++ b/core/navigation/src/main/java/com/teamyg/navigation/NavigationModule.kt
@@ -1,0 +1,16 @@
+package com.teamyg.navigation
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityRetainedComponent
+import dagger.hilt.android.scopes.ActivityRetainedScoped
+
+@Module
+@InstallIn(ActivityRetainedComponent::class)
+object NavigationModule {
+
+    @Provides
+    @ActivityRetainedScoped
+    fun provideNavigator() : Navigator = Navigator(NavigatorConst.INITIAL_NAVIGATION_KEY)
+}

--- a/core/navigation/src/main/java/com/teamyg/navigation/Navigator.kt
+++ b/core/navigation/src/main/java/com/teamyg/navigation/Navigator.kt
@@ -8,12 +8,13 @@ import dagger.hilt.android.scopes.ActivityRetainedScoped
 @ActivityRetainedScoped
 class Navigator(initialNavigationKey: NavKey) {
 
-    val backStack: SnapshotStateList<NavKey> = mutableStateListOf(initialNavigationKey)
+    private val _backStack: SnapshotStateList<NavKey> = mutableStateListOf(initialNavigationKey)
+    val backStack: List<NavKey> get() = _backStack
 
     fun goTo(destination: NavKey){
-        backStack.add(destination)
+        _backStack.add(destination)
     }
     fun onBack() {
-        backStack.removeLastOrNull()
+        _backStack.removeLastOrNull()
     }
 }

--- a/core/navigation/src/main/java/com/teamyg/navigation/Navigator.kt
+++ b/core/navigation/src/main/java/com/teamyg/navigation/Navigator.kt
@@ -1,0 +1,19 @@
+package com.teamyg.navigation
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.navigation3.runtime.NavKey
+import dagger.hilt.android.scopes.ActivityRetainedScoped
+
+@ActivityRetainedScoped
+class Navigator(initialNavigationKey: NavKey) {
+
+    val backStack: SnapshotStateList<NavKey> = mutableStateListOf(initialNavigationKey)
+
+    fun goTo(destination: NavKey){
+        backStack.add(destination)
+    }
+    fun onBack() {
+        backStack.removeLastOrNull()
+    }
+}

--- a/core/navigation/src/main/java/com/teamyg/navigation/NavigatorConst.kt
+++ b/core/navigation/src/main/java/com/teamyg/navigation/NavigatorConst.kt
@@ -1,0 +1,7 @@
+package com.teamyg.navigation
+
+import com.teamyg.login.api.NavKeyLoginHome
+
+object NavigatorConst {
+    val INITIAL_NAVIGATION_KEY = NavKeyLoginHome
+}

--- a/feature/grouphome/impl/src/main/java/com/teamyg/grouphome/impl/EntryBuilder.kt
+++ b/feature/grouphome/impl/src/main/java/com/teamyg/grouphome/impl/EntryBuilder.kt
@@ -1,12 +1,24 @@
 package com.teamyg.grouphome.impl
 
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import com.teamyg.grouphome.api.NavKeyGroupHome
 import com.teamyg.navigation.Navigator
 
 fun EntryProviderScope<NavKey>.featureGroupHomeEntryBuilder(navigator: Navigator) {
-    entry<NavKeyGroupHome> {
-        GroupHomeRoute(navigator)
+    entry<NavKeyGroupHome> { key ->
+        Scaffold { innerPadding ->
+            GroupHomeRoute(
+                navigator = navigator,
+                key = key,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+            )
+        }
     }
 }

--- a/feature/grouphome/impl/src/main/java/com/teamyg/grouphome/impl/EntryBuilder.kt
+++ b/feature/grouphome/impl/src/main/java/com/teamyg/grouphome/impl/EntryBuilder.kt
@@ -1,0 +1,12 @@
+package com.teamyg.grouphome.impl
+
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
+import com.teamyg.grouphome.api.NavKeyGroupHome
+import com.teamyg.navigation.Navigator
+
+fun EntryProviderScope<NavKey>.featureGroupHomeEntryBuilder(navigator: Navigator) {
+    entry<NavKeyGroupHome> {
+        GroupHomeRoute(navigator)
+    }
+}

--- a/feature/grouphome/impl/src/main/java/com/teamyg/grouphome/impl/GroupHomeRoute.kt
+++ b/feature/grouphome/impl/src/main/java/com/teamyg/grouphome/impl/GroupHomeRoute.kt
@@ -1,10 +1,18 @@
 package com.teamyg.grouphome.impl
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.result.LocalResultEventBus
 import com.teamyg.grouphome.api.NavKeyGroupHome
 import com.teamyg.navigation.Navigator
 
@@ -14,12 +22,27 @@ fun GroupHomeRoute(
     key: NavKeyGroupHome,
     modifier: Modifier = Modifier,
 ) {
-    Box(
+    val resultEventBus = LocalResultEventBus.current
+    var returnText by remember { mutableStateOf("") }
+    Column(
         modifier = modifier,
-        contentAlignment = Alignment.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.SpaceAround
     ) {
         Text(
             text = "group home // groupId: ${key.groupId}",
         )
+        TextField(
+            value = returnText,
+            onValueChange = { returnText = it },
+        )
+        Button(
+            onClick = {
+                resultEventBus.sendResult(returnText)
+                navigator.onBack()
+            },
+        ) {
+            Text("return with value")
+        }
     }
 }

--- a/feature/grouphome/impl/src/main/java/com/teamyg/grouphome/impl/GroupHomeRoute.kt
+++ b/feature/grouphome/impl/src/main/java/com/teamyg/grouphome/impl/GroupHomeRoute.kt
@@ -1,24 +1,25 @@
 package com.teamyg.grouphome.impl
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.teamyg.grouphome.api.NavKeyGroupHome
 import com.teamyg.navigation.Navigator
 
 @Composable
 fun GroupHomeRoute(
     navigator: Navigator,
+    key: NavKeyGroupHome,
     modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier,
         contentAlignment = Alignment.Center,
     ) {
         Text(
-            text = "group home",
+            text = "group home // groupId: ${key.groupId}",
         )
     }
 }

--- a/feature/grouphome/impl/src/main/java/com/teamyg/grouphome/impl/NavigationModule.kt
+++ b/feature/grouphome/impl/src/main/java/com/teamyg/grouphome/impl/NavigationModule.kt
@@ -1,0 +1,21 @@
+package com.teamyg.grouphome.impl
+
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
+import com.teamyg.navigation.Navigator
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityRetainedComponent
+import dagger.multibindings.IntoSet
+
+@Module
+@InstallIn(ActivityRetainedComponent::class)
+object NavigationModule {
+
+    @IntoSet
+    @Provides
+    fun provideFeatureGroupHomeEntryBuilder(): EntryProviderScope<NavKey>.(Navigator) -> Unit = {
+        featureGroupHomeEntryBuilder(navigator = it)
+    }
+}

--- a/feature/login/impl/build.gradle.kts
+++ b/feature/login/impl/build.gradle.kts
@@ -8,4 +8,5 @@ android {
 
 dependencies {
     implementation(projects.feature.login.api)
+    implementation(projects.feature.grouphome.api)
 }

--- a/feature/login/impl/src/main/java/com/teamyg/login/impl/EntryBuilder.kt
+++ b/feature/login/impl/src/main/java/com/teamyg/login/impl/EntryBuilder.kt
@@ -1,0 +1,12 @@
+package com.teamyg.login.impl
+
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
+import com.teamyg.login.api.NavKeyLoginHome
+import com.teamyg.navigation.Navigator
+
+fun EntryProviderScope<NavKey>.featureLoginEntryBuilder(navigator: Navigator) {
+    entry<NavKeyLoginHome> {
+        LoginRoute(navigator)
+    }
+}

--- a/feature/login/impl/src/main/java/com/teamyg/login/impl/EntryBuilder.kt
+++ b/feature/login/impl/src/main/java/com/teamyg/login/impl/EntryBuilder.kt
@@ -1,5 +1,9 @@
 package com.teamyg.login.impl
 
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import com.teamyg.login.api.NavKeyLoginHome
@@ -7,6 +11,13 @@ import com.teamyg.navigation.Navigator
 
 fun EntryProviderScope<NavKey>.featureLoginEntryBuilder(navigator: Navigator) {
     entry<NavKeyLoginHome> {
-        LoginRoute(navigator)
+        Scaffold { innerPadding ->
+            LoginRoute(
+                navigator = navigator,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+            )
+        }
     }
 }

--- a/feature/login/impl/src/main/java/com/teamyg/login/impl/LoginRoute.kt
+++ b/feature/login/impl/src/main/java/com/teamyg/login/impl/LoginRoute.kt
@@ -1,11 +1,12 @@
 package com.teamyg.login.impl
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.teamyg.grouphome.api.NavKeyGroupHome
 import com.teamyg.navigation.Navigator
 
 @Composable
@@ -14,11 +15,14 @@ fun LoginRoute(
     modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier,
         contentAlignment = Alignment.Center,
     ) {
         Text(
             text = "login",
+            modifier = Modifier.clickable {
+                navigator.goTo(NavKeyGroupHome(groupId = 1231))
+            }
         )
     }
 }

--- a/feature/login/impl/src/main/java/com/teamyg/login/impl/LoginRoute.kt
+++ b/feature/login/impl/src/main/java/com/teamyg/login/impl/LoginRoute.kt
@@ -1,4 +1,4 @@
-package com.teamyg.grouphome.impl
+package com.teamyg.login.impl
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,7 +9,7 @@ import androidx.compose.ui.Modifier
 import com.teamyg.navigation.Navigator
 
 @Composable
-fun GroupHomeRoute(
+fun LoginRoute(
     navigator: Navigator,
     modifier: Modifier = Modifier,
 ) {
@@ -18,7 +18,7 @@ fun GroupHomeRoute(
         contentAlignment = Alignment.Center,
     ) {
         Text(
-            text = "group home",
+            text = "login",
         )
     }
 }

--- a/feature/login/impl/src/main/java/com/teamyg/login/impl/LoginRoute.kt
+++ b/feature/login/impl/src/main/java/com/teamyg/login/impl/LoginRoute.kt
@@ -1,11 +1,14 @@
 package com.teamyg.login.impl
 
+import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.navigation3.runtime.result.ResultEffect
 import com.teamyg.grouphome.api.NavKeyGroupHome
 import com.teamyg.navigation.Navigator
 
@@ -14,6 +17,12 @@ fun LoginRoute(
     navigator: Navigator,
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
+
+    ResultEffect<String> { returnText ->
+        Toast.makeText(context, returnText, Toast.LENGTH_LONG).show()
+    }
+
     Box(
         modifier = modifier,
         contentAlignment = Alignment.Center,

--- a/feature/login/impl/src/main/java/com/teamyg/login/impl/NavigationModule.kt
+++ b/feature/login/impl/src/main/java/com/teamyg/login/impl/NavigationModule.kt
@@ -1,0 +1,21 @@
+package com.teamyg.login.impl
+
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
+import com.teamyg.navigation.Navigator
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityRetainedComponent
+import dagger.multibindings.IntoSet
+
+@Module
+@InstallIn(ActivityRetainedComponent::class)
+object NavigationModule {
+
+    @IntoSet
+    @Provides
+    fun provideFeatureLoginEntryBuilder(): EntryProviderScope<NavKey>.(Navigator) -> Unit = {
+        featureLoginEntryBuilder(navigator = it)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ retrofit = "3.0.0"
 okhttp = "5.3.2"
 
 #Navigation
-navigation = "1.1.1"
+navigation = "1.2.0-alpha02" # Result Return 을 위한 ResultEventBusNavEntryDecorator 가 1.2.0-alpha02 부터 지원하여, stable 이 아님에도 선택하였습니다
 
 [libraries]
 #gradle plugin


### PR DESCRIPTION
## 요약
<img width="1001" height="602" alt="Image" src="https://github.com/user-attachments/assets/37e28aa0-4569-4743-a0ca-b2b10b64f9ef" />

- Navigation 이동하기와 돌아오기 예시를 추가하였습니다.

## 참조
- [Navigation3 Recipe - event based Return](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/results/event)
- [Navigation3 Recipe - state based Return](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/results/state)

=> 우리는 return  값을 받는 두 방법 (state-based, event-based) 중 **event-based** 를 사용하는 것이 좋아보입니다. 그 이유는 현재 지향하는 구조가 사용자와의 모든 이벤트인 Intent 를 ViewModel 로 끌어올려서 ViewModel 에서 처리하고 State 업데이트하는 구조이기에 값을 return 받는 것도 하나의 Intent 로 보고 ViewModel 로 올려야한다는 관점으로 간다면 event based 를 사용하는 것이 적절해보입니다.


closes #26 