### PR TITLE
[Feature/#52] 커스텀 갤러리 구현

### DIFF
--- a/feature/gallery/api/src/main/java/com/teamyg/gallery/api/NavKeyCustomGalleryPicker.kt
+++ b/feature/gallery/api/src/main/java/com/teamyg/gallery/api/NavKeyCustomGalleryPicker.kt
@@ -1,0 +1,7 @@
+package com.teamyg.gallery.api
+
+import androidx.navigation3.runtime.NavKey
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object NavKeyCustomGalleryPicker : NavKey

--- a/feature/gallery/impl/src/main/AndroidManifest.xml
+++ b/feature/gallery/impl/src/main/AndroidManifest.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
+
 </manifest>

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/component/GalleryImageGridComponent.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/component/GalleryImageGridComponent.kt
@@ -1,0 +1,108 @@
+package com.teamyg.gallery.impl.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.teamyg.gallery.impl.model.GalleryImageGroup
+import com.tjyg.core.ui.preview.PreviewBox
+import com.tjyg.core.ui.preview.YGPreview
+
+@Composable
+internal fun GalleryImageGridComponent(
+    groups: List<GalleryImageGroup>,
+    onClickImage: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(count = 3),
+        modifier = modifier
+            .background(Color.Black)
+            .padding(horizontal = 2.dp),
+    ) {
+        groups.forEach { group ->
+            item(
+                key = "header-${group.date}",
+                span = { GridItemSpan(maxLineSpan) },
+            ) {
+                GalleryDateHeader(date = group.date)
+            }
+
+            items(
+                items = group.images,
+                key = { it },
+            ) { uri ->
+                Box(
+                    modifier = Modifier
+                        .aspectRatio(1f)
+                        .padding(2.dp)
+                        .clickable { onClickImage(uri) },
+                ) {
+                    AsyncImage(
+                        model = uri,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GalleryDateHeader(
+    date: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = date,
+        color = Color.White,
+        style = MaterialTheme.typography.titleSmall,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = 4.dp,
+                vertical = 12.dp,
+            ),
+    )
+}
+
+@YGPreview
+@Composable
+private fun PreviewGalleryImageGridComponent() = PreviewBox {
+    GalleryImageGridComponent(
+        groups = listOf(
+            GalleryImageGroup(
+                date = "2023.07.01",
+                images = listOf(
+                    "test1",
+                    "test2",
+                ),
+            ),
+            GalleryImageGroup(
+                date = "2023.07.02",
+                images = listOf(
+                    "test3",
+                    "test4",
+                ),
+            ),
+        ),
+        onClickImage = {},
+    )
+}

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/component/GalleryPartialAccessBanner.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/component/GalleryPartialAccessBanner.kt
@@ -1,0 +1,55 @@
+package com.teamyg.gallery.impl.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.tjyg.core.ui.preview.PreviewBox
+import com.tjyg.core.ui.preview.YGPreview
+
+@Composable
+internal fun GalleryPartialAccessBanner(
+    onClickManage: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(Color.DarkGray)
+            .padding(
+                horizontal = 16.dp,
+                vertical = 8.dp,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = "일부 사진만 접근할 수 있어요.",
+            color = Color.White,
+        )
+
+        TextButton(onClick = onClickManage) {
+            Text(
+                text = "선택 관리",
+                color = Color.White,
+            )
+        }
+    }
+}
+
+@YGPreview
+@Composable
+private fun PreviewGalleryPartialAccessBanner() = PreviewBox {
+    GalleryPartialAccessBanner(
+        onClickManage = {},
+        modifier = Modifier.fillMaxWidth(),
+    )
+}

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/component/GalleryPermissionRequestComponent.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/component/GalleryPermissionRequestComponent.kt
@@ -51,7 +51,6 @@ internal fun GalleryPermissionRequestComponent(
             }
         }
     }
-
 }
 
 @YGPreview

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/component/GalleryPermissionRequestComponent.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/component/GalleryPermissionRequestComponent.kt
@@ -1,0 +1,79 @@
+package com.teamyg.gallery.impl.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.tjyg.core.ui.preview.PreviewBox
+import com.tjyg.core.ui.preview.YGPreview
+
+@Composable
+internal fun GalleryPermissionRequestComponent(
+    isInit: Boolean,
+    isDeniedPermission: Boolean,
+    onClickGrantPermission: () -> Unit,
+    onClickOpenSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .background(Color.Black)
+            .padding(PaddingValues(24.dp)),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterVertically),
+    ) {
+        if (isInit.not()) {
+            Text(
+                text = when {
+                    isDeniedPermission -> "갤러리 권한이 영구 거부되었습니다.\n설정에서 권한을 허용해 주세요."
+                    else -> "갤러리 권한이 필요합니다."
+                },
+                color = Color.White,
+            )
+
+            when {
+                isDeniedPermission -> Button(onClick = onClickOpenSettings) {
+                    Text(text = "설정 열기")
+                }
+
+                else -> Button(onClick = onClickGrantPermission) {
+                    Text(text = "권한 요청")
+                }
+            }
+        }
+    }
+
+}
+
+@YGPreview
+@Composable
+private fun PreviewGalleryPermissionRequestComponent() = PreviewBox {
+    GalleryPermissionRequestComponent(
+        isInit = true,
+        isDeniedPermission = false,
+        onClickGrantPermission = {},
+        onClickOpenSettings = {},
+        modifier = Modifier.fillMaxSize(),
+    )
+}
+
+@YGPreview
+@Composable
+private fun PreviewGalleryPermissionRequestComponentPermanentlyDenied() = PreviewBox {
+    GalleryPermissionRequestComponent(
+        isInit = true,
+        isDeniedPermission = true,
+        onClickGrantPermission = {},
+        onClickOpenSettings = {},
+        modifier = Modifier.fillMaxSize(),
+    )
+}

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/model/GalleryAccessLevel.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/model/GalleryAccessLevel.kt
@@ -1,0 +1,39 @@
+package com.teamyg.gallery.impl.model
+
+import android.app.Activity
+import android.content.Context
+import com.teamyg.gallery.impl.utils.GalleryPermissionManager
+
+enum class GalleryAccessLevel {
+    INITIAL,
+    DENIED,
+    PERMANENTLY_DENIED,
+    PARTIAL,
+    FULL,
+    ;
+
+    companion object {
+        internal fun resolveAccessLevelOnEnter(context: Context): GalleryAccessLevel = when {
+            GalleryPermissionManager.hasFullAccess(context) -> FULL
+            GalleryPermissionManager.hasPartialAccess(context) -> PARTIAL
+            else -> DENIED
+        }
+
+        internal fun resolveAccessLevelAfterRequest(
+            context: Context,
+            activity: Activity?,
+        ): GalleryAccessLevel {
+            if (GalleryPermissionManager.hasFullAccess(context)) {
+                return FULL
+            }
+
+            if (GalleryPermissionManager.hasPartialAccess(context)) {
+                return PARTIAL
+            }
+
+            val canRetry = activity?.let { GalleryPermissionManager.shouldShowRationale(it) } ?: true
+
+            return if (canRetry) DENIED else PERMANENTLY_DENIED
+        }
+    }
+}

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/model/GalleryAccessLevel.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/model/GalleryAccessLevel.kt
@@ -6,4 +6,29 @@ enum class GalleryAccessLevel {
     PERMANENTLY_DENIED,
     PARTIAL,
     FULL,
+    ;
+
+    val isPartial: Boolean
+        get() = when (this) {
+            PARTIAL -> true
+            else -> false
+        }
+
+    val hasPermission: Boolean
+        get() = when (this) {
+            PARTIAL,
+            FULL,
+            -> true
+
+            else -> false
+        }
+
+    val isDeniedPermission: Boolean
+        get() = when (this) {
+            DENIED,
+            PERMANENTLY_DENIED,
+            -> true
+
+            else -> false
+        }
 }

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/model/GalleryAccessLevel.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/model/GalleryAccessLevel.kt
@@ -1,39 +1,9 @@
 package com.teamyg.gallery.impl.model
 
-import android.app.Activity
-import android.content.Context
-import com.teamyg.gallery.impl.utils.GalleryPermissionManager
-
 enum class GalleryAccessLevel {
     INITIAL,
     DENIED,
     PERMANENTLY_DENIED,
     PARTIAL,
     FULL,
-    ;
-
-    companion object {
-        internal fun resolveAccessLevelOnEnter(context: Context): GalleryAccessLevel = when {
-            GalleryPermissionManager.hasFullAccess(context) -> FULL
-            GalleryPermissionManager.hasPartialAccess(context) -> PARTIAL
-            else -> DENIED
-        }
-
-        internal fun resolveAccessLevelAfterRequest(
-            context: Context,
-            activity: Activity?,
-        ): GalleryAccessLevel {
-            if (GalleryPermissionManager.hasFullAccess(context)) {
-                return FULL
-            }
-
-            if (GalleryPermissionManager.hasPartialAccess(context)) {
-                return PARTIAL
-            }
-
-            val canRetry = activity?.let { GalleryPermissionManager.shouldShowRationale(it) } ?: true
-
-            return if (canRetry) DENIED else PERMANENTLY_DENIED
-        }
-    }
 }

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/model/GalleryAccessLevelPreviewParameterProvider.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/model/GalleryAccessLevelPreviewParameterProvider.kt
@@ -1,0 +1,13 @@
+package com.teamyg.gallery.impl.model
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+
+internal class GalleryAccessLevelPreviewParameterProvider : PreviewParameterProvider<GalleryAccessLevel> {
+    override val values: Sequence<GalleryAccessLevel>
+        get() = sequenceOf(
+            GalleryAccessLevel.DENIED,
+            GalleryAccessLevel.PERMANENTLY_DENIED,
+            GalleryAccessLevel.PARTIAL,
+            GalleryAccessLevel.FULL,
+        )
+}

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/model/GalleryImageGroup.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/model/GalleryImageGroup.kt
@@ -1,0 +1,9 @@
+package com.teamyg.gallery.impl.model
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+data class GalleryImageGroup(
+    val date: String,
+    val images: List<String>,
+)

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/navigation/EntryBuilder.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/navigation/EntryBuilder.kt
@@ -6,7 +6,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
+import com.teamyg.gallery.api.NavKeyCustomGalleryPicker
 import com.teamyg.gallery.api.NavKeySystemGalleryPicker
+import com.teamyg.gallery.impl.route.CustomGalleryPickerRoute
 import com.teamyg.gallery.impl.route.SystemGalleryPickerRoute
 import com.teamyg.navigation.Navigator
 
@@ -14,6 +16,19 @@ fun EntryProviderScope<NavKey>.featureSystemGalleryEntryBuilder(navigator: Navig
     entry<NavKeySystemGalleryPicker> {
         Scaffold { innerPadding ->
             SystemGalleryPickerRoute(
+                navigator = navigator,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+            )
+        }
+    }
+}
+
+fun EntryProviderScope<NavKey>.featureCustomGalleryEntryBuilder(navigator: Navigator) {
+    entry<NavKeyCustomGalleryPicker> {
+        Scaffold { innerPadding ->
+            CustomGalleryPickerRoute(
                 navigator = navigator,
                 modifier = Modifier
                     .fillMaxSize()

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/navigation/NavigationModule.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/navigation/NavigationModule.kt
@@ -17,4 +17,10 @@ object NavigationModule {
     fun provideFeatureSystemGalleryEntryBuilder(): EntryProviderScope<NavKey>.(Navigator) -> Unit = {
         featureSystemGalleryEntryBuilder(navigator = it)
     }
+
+    @IntoSet
+    @Provides
+    fun provideFeatureCustomGalleryEntryBuilder(): EntryProviderScope<NavKey>.(Navigator) -> Unit = {
+        featureCustomGalleryEntryBuilder(navigator = it)
+    }
 }

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/route/CustomGalleryPickerRoute.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/route/CustomGalleryPickerRoute.kt
@@ -1,13 +1,101 @@
 package com.teamyg.gallery.impl.route
 
+import androidx.activity.compose.LocalActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation3.runtime.result.LocalResultEventBus
+import com.teamyg.gallery.impl.model.GalleryAccessLevel
+import com.teamyg.gallery.impl.screen.CustomGalleryPickerScreen
+import com.teamyg.gallery.impl.utils.GalleryMediaProvider
+import com.teamyg.gallery.impl.utils.GalleryPermissionManager
+import com.teamyg.gallery.impl.utils.extension.buildAppSettingsIntent
+import com.teamyg.gallery.impl.viewmodel.CustomGalleryPickerEffect
+import com.teamyg.gallery.impl.viewmodel.CustomGalleryPickerIntent
+import com.teamyg.gallery.impl.viewmodel.CustomGalleryPickerViewModel
 import com.teamyg.navigation.Navigator
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @Composable
 internal fun CustomGalleryPickerRoute(
     navigator: Navigator,
     modifier: Modifier = Modifier,
+    viewModel: CustomGalleryPickerViewModel = hiltViewModel(),
 ) {
+    val context = LocalContext.current
+    val activity = LocalActivity.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val resultEventBus = LocalResultEventBus.current
+    val state by viewModel.state.collectAsStateWithLifecycle()
 
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions(),
+    ) {
+        val access = GalleryAccessLevel.resolveAccessLevelAfterRequest(context, activity)
+        viewModel.processIntent(CustomGalleryPickerIntent.OnPermissionResult(access))
+    }
+
+    LaunchedEffect(viewModel.effect) {
+        viewModel.effect.collect { effect ->
+            when (effect) {
+                is CustomGalleryPickerEffect.RequestPermission -> {
+                    permissionLauncher.launch(GalleryPermissionManager.requiredPermissions)
+                }
+
+                is CustomGalleryPickerEffect.OpenAppSettings -> {
+                    context.startActivity(context.buildAppSettingsIntent())
+                }
+
+                is CustomGalleryPickerEffect.LoadImages -> {
+                    val groups = withContext(Dispatchers.IO) {
+                        GalleryMediaProvider.loadImageGroups(context)
+                    }
+                    viewModel.processIntent(CustomGalleryPickerIntent.OnImagesLoaded(groups))
+                }
+
+                is CustomGalleryPickerEffect.ReturnResult -> {
+                    resultEventBus.sendResult(effect.uri)
+                    navigator.onBack()
+                }
+
+                is CustomGalleryPickerEffect.NavigateToBack -> navigator.onBack()
+            }
+        }
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.processIntent(
+                    CustomGalleryPickerIntent.OnPermissionResult(
+                        access = GalleryAccessLevel.resolveAccessLevelOnEnter(context),
+                    ),
+                )
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    CustomGalleryPickerScreen(
+        state = state,
+        onClickGrantPermission = { viewModel.processIntent(CustomGalleryPickerIntent.OnRequestPermission) },
+        onClickOpenSettings = { viewModel.processIntent(CustomGalleryPickerIntent.OnRequestOpenSettings) },
+        onClickManageMedia = { viewModel.processIntent(CustomGalleryPickerIntent.OnRequestManageMedia) },
+        onClickImage = { viewModel.processIntent(CustomGalleryPickerIntent.OnClickImage(it)) },
+        onClickCancel = { viewModel.processIntent(CustomGalleryPickerIntent.OnCancel) },
+        modifier = modifier,
+    )
 }

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/route/CustomGalleryPickerRoute.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/route/CustomGalleryPickerRoute.kt
@@ -59,7 +59,7 @@ internal fun CustomGalleryPickerRoute(
 
                 is CustomGalleryPickerEffect.LoadImages -> {
                     val groups = withContext(Dispatchers.IO) {
-                        GalleryMediaProvider.loadImageGroups(context)
+                        GalleryMediaProvider.loadImageGroupsByYG(context)
                     }
                     viewModel.processIntent(CustomGalleryPickerIntent.OnImagesLoaded(groups))
                 }

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/route/CustomGalleryPickerRoute.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/route/CustomGalleryPickerRoute.kt
@@ -1,0 +1,13 @@
+package com.teamyg.gallery.impl.route
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.teamyg.navigation.Navigator
+
+@Composable
+internal fun CustomGalleryPickerRoute(
+    navigator: Navigator,
+    modifier: Modifier = Modifier,
+) {
+
+}

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/route/CustomGalleryPickerRoute.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/route/CustomGalleryPickerRoute.kt
@@ -17,7 +17,6 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.result.LocalResultEventBus
-import com.teamyg.gallery.impl.model.GalleryAccessLevel
 import com.teamyg.gallery.impl.screen.CustomGalleryPickerScreen
 import com.teamyg.gallery.impl.utils.GalleryMediaProvider
 import com.teamyg.gallery.impl.utils.GalleryPermissionManager
@@ -45,7 +44,7 @@ internal fun CustomGalleryPickerRoute(
     val permissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestMultiplePermissions(),
     ) {
-        val access = GalleryAccessLevel.resolveAccessLevelAfterRequest(context, activity)
+        val access = GalleryPermissionManager.resolveAccessLevelAfterRequest(context, activity)
         viewModel.processIntent(CustomGalleryPickerIntent.OnPermissionResult(access))
     }
 
@@ -82,7 +81,7 @@ internal fun CustomGalleryPickerRoute(
             if (event == Lifecycle.Event.ON_RESUME) {
                 viewModel.processIntent(
                     CustomGalleryPickerIntent.OnPermissionResult(
-                        access = GalleryAccessLevel.resolveAccessLevelOnEnter(context),
+                        access = GalleryPermissionManager.resolveAccessLevelOnEnter(context),
                     ),
                 )
             }

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/route/CustomGalleryPickerRoute.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/route/CustomGalleryPickerRoute.kt
@@ -1,5 +1,7 @@
 package com.teamyg.gallery.impl.route
 
+import android.app.Activity
+import android.content.Context
 import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -33,8 +35,9 @@ internal fun CustomGalleryPickerRoute(
     modifier: Modifier = Modifier,
     viewModel: CustomGalleryPickerViewModel = hiltViewModel(),
 ) {
-    val context = LocalContext.current
-    val activity = LocalActivity.current
+    val activity: Activity? = LocalActivity.current
+    val context: Context = activity ?: LocalContext.current
+
     val lifecycleOwner = LocalLifecycleOwner.current
     val resultEventBus = LocalResultEventBus.current
     val state by viewModel.state.collectAsStateWithLifecycle()

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/screen/CustomGalleryPickerScreen.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/screen/CustomGalleryPickerScreen.kt
@@ -15,11 +15,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import com.teamyg.gallery.impl.component.GalleryImageGridComponent
 import com.teamyg.gallery.impl.component.GalleryPartialAccessBanner
 import com.teamyg.gallery.impl.component.GalleryPermissionRequestComponent
 import com.teamyg.gallery.impl.model.GalleryAccessLevel
+import com.teamyg.gallery.impl.model.GalleryAccessLevelPreviewParameterProvider
 import com.teamyg.gallery.impl.model.GalleryImageGroup
 import com.teamyg.gallery.impl.viewmodel.CustomGalleryPickerState
 import com.tjyg.core.ui.preview.PreviewBox
@@ -113,58 +115,12 @@ private fun GalleryContent(
 
 @YGPreview
 @Composable
-private fun PreviewCustomGalleryPickerScreenPermissionDenied() = PreviewBox {
+private fun PreviewCustomGalleryPickerScreen(
+    @PreviewParameter(GalleryAccessLevelPreviewParameterProvider::class) access: GalleryAccessLevel,
+) = PreviewBox {
     CustomGalleryPickerScreen(
         state = CustomGalleryPickerState(
-            access = GalleryAccessLevel.DENIED,
-        ),
-        onClickGrantPermission = {},
-        onClickOpenSettings = {},
-        onClickManageMedia = {},
-        onClickImage = {},
-        onClickCancel = {},
-        modifier = Modifier.fillMaxSize(),
-    )
-}
-
-@YGPreview
-@Composable
-private fun PreviewCustomGalleryPickerScreenPermissionPermanentlyDenied() = PreviewBox {
-    CustomGalleryPickerScreen(
-        state = CustomGalleryPickerState(
-            access = GalleryAccessLevel.PERMANENTLY_DENIED,
-        ),
-        onClickGrantPermission = {},
-        onClickOpenSettings = {},
-        onClickManageMedia = {},
-        onClickImage = {},
-        onClickCancel = {},
-        modifier = Modifier.fillMaxSize(),
-    )
-}
-
-@YGPreview
-@Composable
-private fun PreviewCustomGalleryPickerScreenPermissionPartial() = PreviewBox {
-    CustomGalleryPickerScreen(
-        state = CustomGalleryPickerState(
-            access = GalleryAccessLevel.PARTIAL,
-        ),
-        onClickGrantPermission = {},
-        onClickOpenSettings = {},
-        onClickManageMedia = {},
-        onClickImage = {},
-        onClickCancel = {},
-        modifier = Modifier.fillMaxSize(),
-    )
-}
-
-@YGPreview
-@Composable
-private fun PreviewCustomGalleryPickerScreenEmpty() = PreviewBox {
-    CustomGalleryPickerScreen(
-        state = CustomGalleryPickerState(
-            access = GalleryAccessLevel.FULL,
+            access = access,
         ),
         onClickGrantPermission = {},
         onClickOpenSettings = {},

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/screen/CustomGalleryPickerScreen.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/screen/CustomGalleryPickerScreen.kt
@@ -1,0 +1,176 @@
+package com.teamyg.gallery.impl.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.teamyg.gallery.impl.component.GalleryImageGridComponent
+import com.teamyg.gallery.impl.component.GalleryPartialAccessBanner
+import com.teamyg.gallery.impl.component.GalleryPermissionRequestComponent
+import com.teamyg.gallery.impl.model.GalleryAccessLevel
+import com.teamyg.gallery.impl.model.GalleryImageGroup
+import com.teamyg.gallery.impl.viewmodel.CustomGalleryPickerState
+import com.tjyg.core.ui.preview.PreviewBox
+import com.tjyg.core.ui.preview.YGPreview
+
+@Composable
+internal fun CustomGalleryPickerScreen(
+    state: CustomGalleryPickerState,
+    onClickGrantPermission: () -> Unit,
+    onClickOpenSettings: () -> Unit,
+    onClickManageMedia: () -> Unit,
+    onClickImage: (String) -> Unit,
+    onClickCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (state.hasPermission) {
+        true -> GalleryContent(
+            isPartial = state.access == GalleryAccessLevel.PARTIAL,
+            isLoading = state.isLoading,
+            isEmpty = state.isEmpty,
+            groups = state.groups,
+            onClickManageMedia = onClickManageMedia,
+            onClickImage = onClickImage,
+            onClickCancel = onClickCancel,
+            modifier = modifier,
+        )
+
+        false -> GalleryPermissionRequestComponent(
+            isInit = state.access == GalleryAccessLevel.INITIAL,
+            isDeniedPermission = state.isDeniedPermission,
+            onClickGrantPermission = onClickGrantPermission,
+            onClickOpenSettings = onClickOpenSettings,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun GalleryContent(
+    isPartial: Boolean,
+    isLoading: Boolean,
+    isEmpty: Boolean,
+    groups: List<GalleryImageGroup>,
+    onClickManageMedia: () -> Unit,
+    onClickImage: (String) -> Unit,
+    onClickCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.background(Color.Black)) {
+        if (isPartial) {
+            GalleryPartialAccessBanner(
+                onClickManage = onClickManageMedia,
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            when {
+                isLoading -> CircularProgressIndicator(color = Color.White)
+
+                isEmpty -> Text(
+                    text = "표시할 이미지가 없습니다.",
+                    color = Color.White,
+                )
+
+                else -> GalleryImageGridComponent(
+                    groups = groups,
+                    onClickImage = onClickImage,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(PaddingValues(16.dp)),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Button(onClick = onClickCancel) {
+                Text(text = "취소")
+            }
+        }
+    }
+}
+
+@YGPreview
+@Composable
+private fun PreviewCustomGalleryPickerScreenPermissionDenied() = PreviewBox {
+    CustomGalleryPickerScreen(
+        state = CustomGalleryPickerState(
+            access = GalleryAccessLevel.DENIED,
+        ),
+        onClickGrantPermission = {},
+        onClickOpenSettings = {},
+        onClickManageMedia = {},
+        onClickImage = {},
+        onClickCancel = {},
+        modifier = Modifier.fillMaxSize(),
+    )
+}
+
+@YGPreview
+@Composable
+private fun PreviewCustomGalleryPickerScreenPermissionPermanentlyDenied() = PreviewBox {
+    CustomGalleryPickerScreen(
+        state = CustomGalleryPickerState(
+            access = GalleryAccessLevel.PERMANENTLY_DENIED,
+        ),
+        onClickGrantPermission = {},
+        onClickOpenSettings = {},
+        onClickManageMedia = {},
+        onClickImage = {},
+        onClickCancel = {},
+        modifier = Modifier.fillMaxSize(),
+    )
+}
+
+@YGPreview
+@Composable
+private fun PreviewCustomGalleryPickerScreenPermissionPartial() = PreviewBox {
+    CustomGalleryPickerScreen(
+        state = CustomGalleryPickerState(
+            access = GalleryAccessLevel.PARTIAL,
+        ),
+        onClickGrantPermission = {},
+        onClickOpenSettings = {},
+        onClickManageMedia = {},
+        onClickImage = {},
+        onClickCancel = {},
+        modifier = Modifier.fillMaxSize(),
+    )
+}
+
+@YGPreview
+@Composable
+private fun PreviewCustomGalleryPickerScreenEmpty() = PreviewBox {
+    CustomGalleryPickerScreen(
+        state = CustomGalleryPickerState(
+            access = GalleryAccessLevel.FULL,
+        ),
+        onClickGrantPermission = {},
+        onClickOpenSettings = {},
+        onClickManageMedia = {},
+        onClickImage = {},
+        onClickCancel = {},
+        modifier = Modifier.fillMaxSize(),
+    )
+}

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/screen/CustomGalleryPickerScreen.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/screen/CustomGalleryPickerScreen.kt
@@ -35,9 +35,9 @@ internal fun CustomGalleryPickerScreen(
     onClickCancel: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    when (state.hasPermission) {
+    when (state.access.hasPermission) {
         true -> GalleryContent(
-            isPartial = state.access == GalleryAccessLevel.PARTIAL,
+            isPartial = state.access.isPartial,
             isLoading = state.isLoading,
             isEmpty = state.isEmpty,
             groups = state.groups,
@@ -49,7 +49,7 @@ internal fun CustomGalleryPickerScreen(
 
         false -> GalleryPermissionRequestComponent(
             isInit = state.access == GalleryAccessLevel.INITIAL,
-            isDeniedPermission = state.isDeniedPermission,
+            isDeniedPermission = state.access.isDeniedPermission,
             onClickGrantPermission = onClickGrantPermission,
             onClickOpenSettings = onClickOpenSettings,
             modifier = modifier,

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/utils/GalleryMediaProvider.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/utils/GalleryMediaProvider.kt
@@ -6,15 +6,24 @@ import android.database.Cursor
 import android.net.Uri
 import android.provider.MediaStore
 import com.teamyg.gallery.impl.model.GalleryImageGroup
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.format
 import kotlinx.datetime.format.Padding
 import kotlinx.datetime.format.char
+import kotlinx.datetime.minus
 import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Instant
 
 object GalleryMediaProvider {
+    private const val DAY_BOUNDARY_HOUR = 3
+
     private val collectionUri: Uri? = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
 
     private val projection: Array<String> = arrayOf(
@@ -26,6 +35,10 @@ object GalleryMediaProvider {
     private const val SORT_ORDER: String =
         "COALESCE(${MediaStore.Images.Media.DATE_TAKEN}, ${MediaStore.Images.Media.DATE_ADDED} * 1000) DESC"
 
+    private const val SELECTION: String =
+        "(${MediaStore.Images.Media.DATE_TAKEN} >= ? AND ${MediaStore.Images.Media.DATE_TAKEN} < ?) " +
+            "OR ${MediaStore.Images.Media.DATE_TAKEN} IS NULL"
+
     private val dateFormat = LocalDateTime.Format {
         year()
         char('.')
@@ -34,6 +47,9 @@ object GalleryMediaProvider {
         this@Format.day(padding = Padding.ZERO)
     }
 
+    /**
+     * 전체 이미지를 가져와서 날짜별로 그룹핑
+     */
     fun loadImageGroups(context: Context): List<GalleryImageGroup> {
         val uri = collectionUri ?: return emptyList()
 
@@ -64,6 +80,87 @@ object GalleryMediaProvider {
 
                     val dateKey: String = Instant
                         .fromEpochMilliseconds(timestampMs)
+                        .toLocalDateTime(timeZone)
+                        .format(dateFormat)
+
+                    val imageUri: String = ContentUris
+                        .withAppendedId(uri, id)
+                        .toString()
+
+                    grouped
+                        .getOrPut(dateKey) { mutableListOf() }
+                        .add(imageUri)
+                }
+            }
+
+        return grouped.map { (date, uris) ->
+            GalleryImageGroup(
+                date = date,
+                images = uris.toList(),
+            )
+        }
+    }
+
+    /**
+     * 전체 이미지를 가져와서 날짜별로 그룹핑
+     * 대신 당일 새벽 3시 부터 익일 새벽 2시 59분까지
+     * e.g. 6일 03:00 ~ 7일 02:59
+     */
+    fun loadImageGroupsByYG(context: Context): List<GalleryImageGroup>  {
+        val uri = collectionUri ?: return emptyList()
+
+        val resolver = context.contentResolver
+        val timeZone = TimeZone.currentSystemDefault()
+
+        val now: LocalDateTime = Clock.System.now().toLocalDateTime(timeZone)
+        val anchorDate: LocalDate = when (now.time >= LocalTime(DAY_BOUNDARY_HOUR, 0)) {
+            true -> now.date
+            false -> now.date.minus(1, DateTimeUnit.DAY)
+        }
+
+        val startInstant: Instant = anchorDate
+            .atStartOfDayIn(timeZone)
+            .plus(DAY_BOUNDARY_HOUR.hours)
+        val endInstant: Instant = startInstant.plus(24.hours)
+
+        val startMs: Long = startInstant.toEpochMilliseconds()
+        val endMs: Long = endInstant.toEpochMilliseconds()
+
+        val selectionArgs: Array<String> = arrayOf(
+            startMs.toString(),
+            endMs.toString(),
+        )
+
+        val grouped = linkedMapOf<String, MutableList<String>>()
+
+        resolver
+            .query(
+                uri,
+                projection,
+                SELECTION,
+                selectionArgs,
+                SORT_ORDER,
+            )?.use { cursor ->
+                val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
+                val takenColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATE_TAKEN)
+                val addedColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATE_ADDED)
+
+                while (cursor.moveToNext()) {
+                    val id: Long = cursor.getLong(idColumn)
+
+                    val timestampMs: Long = resolveTimestampMs(
+                        cursor = cursor,
+                        takenColumn = takenColumn,
+                        addedColumn = addedColumn,
+                    )
+
+                    if (timestampMs !in startMs..<endMs) {
+                        continue
+                    }
+
+                    val dateKey: String = Instant
+                        .fromEpochMilliseconds(timestampMs)
+                        .minus(DAY_BOUNDARY_HOUR.hours)
                         .toLocalDateTime(timeZone)
                         .format(dateFormat)
 

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/utils/GalleryMediaProvider.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/utils/GalleryMediaProvider.kt
@@ -1,0 +1,105 @@
+package com.teamyg.gallery.impl.utils
+
+import android.content.ContentUris
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+import android.provider.MediaStore
+import com.teamyg.gallery.impl.model.GalleryImageGroup
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.format
+import kotlinx.datetime.format.Padding
+import kotlinx.datetime.format.char
+import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Instant
+
+object GalleryMediaProvider {
+    private val collectionUri: Uri? = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+
+    private val projection: Array<String> = arrayOf(
+        MediaStore.Images.Media._ID,
+        MediaStore.Images.Media.DATE_TAKEN,
+        MediaStore.Images.Media.DATE_ADDED,
+    )
+
+    private const val SORT_ORDER: String =
+        "COALESCE(${MediaStore.Images.Media.DATE_TAKEN}, ${MediaStore.Images.Media.DATE_ADDED} * 1000) DESC"
+
+    private val dateFormat = LocalDateTime.Format {
+        year()
+        char('.')
+        monthNumber()
+        char('.')
+        this@Format.day(padding = Padding.ZERO)
+    }
+
+    fun loadImageGroups(context: Context): List<GalleryImageGroup> {
+        val uri = collectionUri ?: return emptyList()
+
+        val resolver = context.contentResolver
+        val timeZone = TimeZone.currentSystemDefault()
+        val grouped = linkedMapOf<String, MutableList<String>>()
+
+        resolver
+            .query(
+                uri,
+                projection,
+                null,
+                null,
+                SORT_ORDER,
+            )?.use { cursor ->
+                val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
+                val takenColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATE_TAKEN)
+                val addedColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATE_ADDED)
+
+                while (cursor.moveToNext()) {
+                    val id: Long = cursor.getLong(idColumn)
+
+                    val timestampMs: Long = resolveTimestampMs(
+                        cursor = cursor,
+                        takenColumn = takenColumn,
+                        addedColumn = addedColumn,
+                    )
+
+                    val dateKey: String = Instant
+                        .fromEpochMilliseconds(timestampMs)
+                        .toLocalDateTime(timeZone)
+                        .format(dateFormat)
+
+                    val imageUri: String = ContentUris
+                        .withAppendedId(uri, id)
+                        .toString()
+
+                    grouped
+                        .getOrPut(dateKey) { mutableListOf() }
+                        .add(imageUri)
+                }
+            }
+
+        return grouped.map { (date, uris) ->
+            GalleryImageGroup(
+                date = date,
+                images = uris.toList(),
+            )
+        }
+    }
+
+    private fun resolveTimestampMs(
+        cursor: Cursor,
+        takenColumn: Int,
+        addedColumn: Int,
+    ): Long {
+        val takenMs = when (!cursor.isNull(takenColumn)) {
+            true -> cursor.getLong(takenColumn)
+            false -> 0L
+        }
+
+        if (takenMs > 0L) {
+            return takenMs
+        }
+
+        val addedSeconds = cursor.getLong(addedColumn)
+        return addedSeconds * 1000L
+    }
+}

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/utils/GalleryMediaProvider.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/utils/GalleryMediaProvider.kt
@@ -106,7 +106,7 @@ object GalleryMediaProvider {
      * 대신 당일 새벽 3시 부터 익일 새벽 2시 59분까지
      * e.g. 6일 03:00 ~ 7일 02:59
      */
-    fun loadImageGroupsByYG(context: Context): List<GalleryImageGroup>  {
+    fun loadImageGroupsByYG(context: Context): List<GalleryImageGroup> {
         val uri = collectionUri ?: return emptyList()
 
         val resolver = context.contentResolver

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/utils/GalleryPermissionManager.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/utils/GalleryPermissionManager.kt
@@ -1,0 +1,65 @@
+package com.teamyg.gallery.impl.utils
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+
+internal object GalleryPermissionManager {
+    private val primaryPermission: String = when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> Manifest.permission.READ_MEDIA_IMAGES
+        else -> Manifest.permission.READ_EXTERNAL_STORAGE
+    }
+
+    val requiredPermissions: Array<String> = when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> arrayOf(
+            Manifest.permission.READ_MEDIA_IMAGES,
+            Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED,
+        )
+
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> arrayOf(
+            Manifest.permission.READ_MEDIA_IMAGES,
+        )
+
+        else -> arrayOf(
+            Manifest.permission.READ_EXTERNAL_STORAGE,
+        )
+    }
+
+    fun hasFullAccess(context: Context): Boolean = when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU ->
+            isGranted(
+                context = context,
+                permission = Manifest.permission.READ_MEDIA_IMAGES,
+            )
+
+        else ->
+            isGranted(
+                context = context,
+                permission = Manifest.permission.READ_EXTERNAL_STORAGE,
+            )
+    }
+
+    fun hasPartialAccess(context: Context): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+        isGranted(
+            context = context,
+            permission = Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED,
+        ) &&
+        !isGranted(
+            context = context,
+            permission = Manifest.permission.READ_MEDIA_IMAGES,
+        )
+
+    fun shouldShowRationale(activity: Activity): Boolean = ActivityCompat.shouldShowRequestPermissionRationale(
+        activity,
+        primaryPermission,
+    )
+
+    private fun isGranted(
+        context: Context,
+        permission: String,
+    ): Boolean = ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+}

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/utils/GalleryPermissionManager.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/utils/GalleryPermissionManager.kt
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import com.teamyg.gallery.impl.model.GalleryAccessLevel
 
 internal object GalleryPermissionManager {
     private val primaryPermission: String = when {
@@ -57,6 +58,29 @@ internal object GalleryPermissionManager {
         activity,
         primaryPermission,
     )
+
+    fun resolveAccessLevelOnEnter(context: Context): GalleryAccessLevel = when {
+        hasFullAccess(context) -> GalleryAccessLevel.FULL
+        hasPartialAccess(context) -> GalleryAccessLevel.PARTIAL
+        else -> GalleryAccessLevel.DENIED
+    }
+
+    fun resolveAccessLevelAfterRequest(
+        context: Context,
+        activity: Activity?,
+    ): GalleryAccessLevel {
+        if (hasFullAccess(context)) {
+            return GalleryAccessLevel.FULL
+        }
+
+        if (hasPartialAccess(context)) {
+            return GalleryAccessLevel.PARTIAL
+        }
+
+        val canRetry = activity?.let { shouldShowRationale(it) } ?: true
+
+        return if (canRetry) GalleryAccessLevel.DENIED else GalleryAccessLevel.PERMANENTLY_DENIED
+    }
 
     private fun isGranted(
         context: Context,

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/utils/extension/Context.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/utils/extension/Context.kt
@@ -1,0 +1,15 @@
+package com.teamyg.gallery.impl.utils.extension
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+
+internal fun Context.buildAppSettingsIntent(): Intent {
+    val packageName = this.packageName
+
+    return Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+        data = Uri.fromParts("package", packageName, null)
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+}

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/viewmodel/CustomGalleryPickerViewModel.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/viewmodel/CustomGalleryPickerViewModel.kt
@@ -65,9 +65,7 @@ sealed class CustomGalleryPickerIntent private constructor() : UiIntent {
 @HiltViewModel
 class CustomGalleryPickerViewModel
 @Inject
-constructor(
-
-) : BaseViewModel<CustomGalleryPickerState, CustomGalleryPickerIntent, CustomGalleryPickerEffect>(
+constructor() : BaseViewModel<CustomGalleryPickerState, CustomGalleryPickerIntent, CustomGalleryPickerEffect>(
     initialState = CustomGalleryPickerState(),
 ) {
     override fun processIntent(intent: CustomGalleryPickerIntent) {

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/viewmodel/CustomGalleryPickerViewModel.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/viewmodel/CustomGalleryPickerViewModel.kt
@@ -75,13 +75,25 @@ constructor() : BaseViewModel<CustomGalleryPickerState, CustomGalleryPickerInten
     }
 
     private fun handleOnPermissionResult(intent: CustomGalleryPickerIntent.OnPermissionResult) {
-        val access: GalleryAccessLevel = intent.access
+        when (intent.access.hasPermission) {
+            true -> {
+                updateState {
+                    copy(
+                        isLoading = true,
+                        access = access,
+                    )
+                }
 
-        updateState { copy(access = access) }
+                postSideEffect(CustomGalleryPickerEffect.LoadImages)
+            }
 
-        if (access == GalleryAccessLevel.PARTIAL || access == GalleryAccessLevel.FULL) {
-            updateState { copy(isLoading = true) }
-            postSideEffect(CustomGalleryPickerEffect.LoadImages)
+            false -> {
+                updateState {
+                    copy(
+                        access = access,
+                    )
+                }
+            }
         }
     }
 

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/viewmodel/CustomGalleryPickerViewModel.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/viewmodel/CustomGalleryPickerViewModel.kt
@@ -16,12 +16,6 @@ data class CustomGalleryPickerState(
     val access: GalleryAccessLevel = GalleryAccessLevel.INITIAL,
     val groups: List<GalleryImageGroup> = emptyList(),
 ) : UiState {
-    val hasPermission: Boolean
-        get() = access == GalleryAccessLevel.PARTIAL || access == GalleryAccessLevel.FULL
-
-    val isDeniedPermission: Boolean
-        get() = access == GalleryAccessLevel.DENIED || access == GalleryAccessLevel.PERMANENTLY_DENIED
-
     val isEmpty: Boolean
         get() = groups.all { it.images.isEmpty() }
 }

--- a/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/viewmodel/CustomGalleryPickerViewModel.kt
+++ b/feature/gallery/impl/src/main/java/com/teamyg/gallery/impl/viewmodel/CustomGalleryPickerViewModel.kt
@@ -1,0 +1,124 @@
+package com.teamyg.gallery.impl.viewmodel
+
+import androidx.compose.runtime.Immutable
+import com.teamyg.gallery.impl.model.GalleryAccessLevel
+import com.teamyg.gallery.impl.model.GalleryImageGroup
+import com.tjyg.core.ui.BaseViewModel
+import com.tjyg.core.ui.UiIntent
+import com.tjyg.core.ui.UiSideEffect
+import com.tjyg.core.ui.UiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@Immutable
+data class CustomGalleryPickerState(
+    val isLoading: Boolean = false,
+    val access: GalleryAccessLevel = GalleryAccessLevel.INITIAL,
+    val groups: List<GalleryImageGroup> = emptyList(),
+) : UiState {
+    val hasPermission: Boolean
+        get() = access == GalleryAccessLevel.PARTIAL || access == GalleryAccessLevel.FULL
+
+    val isDeniedPermission: Boolean
+        get() = access == GalleryAccessLevel.DENIED || access == GalleryAccessLevel.PERMANENTLY_DENIED
+
+    val isEmpty: Boolean
+        get() = groups.all { it.images.isEmpty() }
+}
+
+sealed class CustomGalleryPickerEffect private constructor() : UiSideEffect {
+    data object RequestPermission : CustomGalleryPickerEffect()
+
+    data object OpenAppSettings : CustomGalleryPickerEffect()
+
+    data object LoadImages : CustomGalleryPickerEffect()
+
+    data class ReturnResult(
+        val uri: String,
+    ) : CustomGalleryPickerEffect()
+
+    data object NavigateToBack : CustomGalleryPickerEffect()
+}
+
+sealed class CustomGalleryPickerIntent private constructor() : UiIntent {
+    data class OnPermissionResult(
+        val access: GalleryAccessLevel,
+    ) : CustomGalleryPickerIntent()
+
+    data object OnRequestPermission : CustomGalleryPickerIntent()
+
+    data object OnRequestOpenSettings : CustomGalleryPickerIntent()
+
+    data object OnRequestManageMedia : CustomGalleryPickerIntent()
+
+    data class OnImagesLoaded(
+        val groups: List<GalleryImageGroup>,
+    ) : CustomGalleryPickerIntent()
+
+    data class OnClickImage(
+        val uri: String,
+    ) : CustomGalleryPickerIntent()
+
+    data object OnCancel : CustomGalleryPickerIntent()
+}
+
+@HiltViewModel
+class CustomGalleryPickerViewModel
+@Inject
+constructor(
+
+) : BaseViewModel<CustomGalleryPickerState, CustomGalleryPickerIntent, CustomGalleryPickerEffect>(
+    initialState = CustomGalleryPickerState(),
+) {
+    override fun processIntent(intent: CustomGalleryPickerIntent) {
+        when (intent) {
+            is CustomGalleryPickerIntent.OnPermissionResult -> handleOnPermissionResult(intent)
+            is CustomGalleryPickerIntent.OnRequestPermission -> handleOnRequestPermission()
+            is CustomGalleryPickerIntent.OnRequestOpenSettings -> handleOnRequestOpenSettings()
+            is CustomGalleryPickerIntent.OnRequestManageMedia -> handleOnRequestManageMedia()
+            is CustomGalleryPickerIntent.OnImagesLoaded -> handleOnImagesLoaded(intent)
+            is CustomGalleryPickerIntent.OnClickImage -> handleOnClickImage(intent)
+            is CustomGalleryPickerIntent.OnCancel -> handleOnCancel()
+        }
+    }
+
+    private fun handleOnPermissionResult(intent: CustomGalleryPickerIntent.OnPermissionResult) {
+        val access: GalleryAccessLevel = intent.access
+
+        updateState { copy(access = access) }
+
+        if (access == GalleryAccessLevel.PARTIAL || access == GalleryAccessLevel.FULL) {
+            updateState { copy(isLoading = true) }
+            postSideEffect(CustomGalleryPickerEffect.LoadImages)
+        }
+    }
+
+    private fun handleOnRequestPermission() {
+        postSideEffect(CustomGalleryPickerEffect.RequestPermission)
+    }
+
+    private fun handleOnRequestOpenSettings() {
+        postSideEffect(CustomGalleryPickerEffect.OpenAppSettings)
+    }
+
+    private fun handleOnRequestManageMedia() {
+        postSideEffect(CustomGalleryPickerEffect.RequestPermission)
+    }
+
+    private fun handleOnImagesLoaded(intent: CustomGalleryPickerIntent.OnImagesLoaded) {
+        updateState {
+            copy(
+                isLoading = false,
+                groups = intent.groups,
+            )
+        }
+    }
+
+    private fun handleOnClickImage(intent: CustomGalleryPickerIntent.OnClickImage) {
+        postSideEffect(CustomGalleryPickerEffect.ReturnResult(intent.uri))
+    }
+
+    private fun handleOnCancel() {
+        postSideEffect(CustomGalleryPickerEffect.NavigateToBack)
+    }
+}


### PR DESCRIPTION
## 📌 Summary (필수)
<!-- 이 PR에서 무엇을 왜 변경했는지 간략히 설명해주세요 -->
- 커스텀 갤러리 구현
- 새벽 03:00 기준으로 이미지 로드 확인

---

## ✅ Checklist (필수)
- [x] 셀프 코드 리뷰 완료
- [x] 코드 컨벤션 확인 완료
- [x] UI 변경 시 스크린샷 첨부
- [ ] 관련 테스트 추가 / 수정
- [x] 로컬 테스트 통과
- [x] 머지 대상 브랜치 확인 (`develop` / `main` / 기타)

---

## 🔗 Related Issue (선택)
Closes #52 

---

## 📱 Screenshots / Screen Recording (선택)
<!-- UI 변경이 있을 경우 Before / After 스크린샷 또는 GIF를 첨부해주세요 -->

| 권한 | 갤러리 (모두 허용) | 갤러리 (부분 허용) |
|--------|-------|------|
| <img width="504" height="1081" alt="image" src="https://github.com/user-attachments/assets/8c843527-86db-49b5-b237-92194b88d089" /> | <img width="500" height="1083" alt="image" src="https://github.com/user-attachments/assets/a86becb0-cef0-4098-8303-951122fa1fc4" /> | <img width="501" height="1083" alt="image" src="https://github.com/user-attachments/assets/8553600c-4918-49df-b71e-8b6999f10d2a" /> |


---

## 💬 Notes for Reviewer (선택)
<!-- 리뷰어가 특히 집중해서 봐야 할 부분이나 참고사항 -->
GalleryMediaProvider 에 두가지 기능이 있습니다
- loadImageGroups -> 전체 이미지 조회
- loadImageGroupsByYG -> 우리가 설계한 03:00 ~ 02:59 스펙 적용

---

## 🧪 How to Test (선택)
<!-- 리뷰어가 재현할 수 있도록 테스트 방법을 적어주세요 -->
1. nav key 변경
2. canvas image add event 변경
