### PR TITLE
[Bugfix] backstack size 관련 크래시 발생 방어로직 삽입

### DIFF
--- a/core/navigation/src/main/java/com/teamyg/parfait/core/navigation/Navigator.kt
+++ b/core/navigation/src/main/java/com/teamyg/parfait/core/navigation/Navigator.kt
@@ -15,6 +15,11 @@ class Navigator(initialNavigationKey: NavKey) {
     }
 
     fun onBack() {
+        if (_backStack.size <= 1) {
+            // ResultEffect 발동 상황에서 사이즈가 1인 경우 크래시 발생
+            return
+        }
+
         _backStack.removeLastOrNull()
     }
 


### PR DESCRIPTION
## 📌 Summary (필수)
<!-- 이 PR에서 무엇을 왜 변경했는지 간략히 설명해주세요 -->
- ResultEffect 로 네비게이션 할 때 빠르게 클릭할 경우 크래시 발생하는 현상 방어

---

## ✅ Checklist (필수)
- [x] 셀프 코드 리뷰 완료
- [x] 코드 컨벤션 확인 완료
- [ ] UI 변경 시 스크린샷 첨부
- [ ] 관련 테스트 추가 / 수정
- [x] 로컬 테스트 통과
- [x] 머지 대상 브랜치 확인 (`develop` / `main` / 기타)

---

## 🔗 Related Issue (선택)
Closes #이슈번호

---

## 📱 Screenshots / Screen Recording (선택)
<!-- UI 변경이 있을 경우 Before / After 스크린샷 또는 GIF를 첨부해주세요 -->

| Before | After |
|--------|-------|
|        |       |

---

## 💬 Notes for Reviewer (선택)
<!-- 리뷰어가 특히 집중해서 봐야 할 부분이나 참고사항 -->


---

## 🧪 How to Test (선택)
<!-- 리뷰어가 재현할 수 있도록 테스트 방법을 적어주세요 -->
1. navKey Canvas Image add 로 변경
2. 갤러리에서 선택
3. 이미지 선택
4. 뒤로
5. 2 -> 3 -> 4 -> 2 플로우 빠른 속도로 계속 실행

