### PR TITLE
[Bugfix] 카카오톡 로그인이 실기기에서 불가능한 이슈 수정

### DIFF
--- a/app/src/main/java/com/teamyg/parfait/BaseApplication.kt
+++ b/app/src/main/java/com/teamyg/parfait/BaseApplication.kt
@@ -2,12 +2,18 @@ package com.teamyg.parfait
 
 import android.app.Application
 import com.kakao.sdk.common.KakaoSdk
+import com.teamyg.parfait.data.utils.CurrentActivityHolder
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
 class BaseApplication : Application() {
+    @Inject
+    lateinit var currentActivityHolder: CurrentActivityHolder
+
     override fun onCreate() {
         super.onCreate()
         KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APP_KEY)
+        registerActivityLifecycleCallbacks(currentActivityHolder)
     }
 }

--- a/data/src/main/java/com/teamyg/parfait/data/repository/KakaoUserRepositoryImpl.kt
+++ b/data/src/main/java/com/teamyg/parfait/data/repository/KakaoUserRepositoryImpl.kt
@@ -1,9 +1,11 @@
 package com.teamyg.parfait.data.repository
 
+import android.app.Activity
 import android.content.Context
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
+import com.teamyg.parfait.data.utils.CurrentActivityHolder
 import com.teamyg.parfait.domain.model.KakaoLoginResult
 import com.teamyg.parfait.domain.repository.KakaoUserRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -16,13 +18,24 @@ class KakaoUserRepositoryImpl
 @Inject
 constructor(
     @ApplicationContext private val context: Context,
+    private val activityHolder: CurrentActivityHolder,
     private val userApiClient: UserApiClient,
 ) : KakaoUserRepository {
     override fun isKakaoTalkLoginAvailable(): Boolean = userApiClient.isKakaoTalkLoginAvailable(context)
 
     override suspend fun loginWithKakaoTalk(): KakaoLoginResult = suspendCancellableCoroutine { continuation ->
+        val activity: Activity? = activityHolder.currentActivity
+
+        if (activity == null) {
+            continuation.resume(
+                value = KakaoLoginResult.Failure(throwable = IllegalStateException("no active Activity")),
+                onCancellation = null,
+            )
+            return@suspendCancellableCoroutine
+        }
+
         userApiClient.loginWithKakaoTalk(
-            context = context,
+            context = activity,
             callback = { token, error ->
                 when {
                     token != null -> {

--- a/data/src/main/java/com/teamyg/parfait/data/utils/CurrentActivityHolder.kt
+++ b/data/src/main/java/com/teamyg/parfait/data/utils/CurrentActivityHolder.kt
@@ -14,17 +14,17 @@ import javax.inject.Singleton
 class CurrentActivityHolder
 @Inject
 constructor() : Application.ActivityLifecycleCallbacks {
-    private var currentActivity: WeakReference<Activity>? = null
-
-    fun current(): Activity? = currentActivity?.get()
+    private var _currentActivity: WeakReference<Activity>? = null
+    val currentActivity: Activity?
+        get() = _currentActivity?.get()
 
     override fun onActivityResumed(activity: Activity) {
-        currentActivity = WeakReference(activity)
+        _currentActivity = WeakReference(activity)
     }
 
     override fun onActivityPaused(activity: Activity) {
-        if (currentActivity?.get() === activity) {
-            currentActivity = null
+        if (_currentActivity?.get() === activity) {
+            _currentActivity = null
         }
     }
 

--- a/data/src/main/java/com/teamyg/parfait/data/utils/CurrentActivityHolder.kt
+++ b/data/src/main/java/com/teamyg/parfait/data/utils/CurrentActivityHolder.kt
@@ -28,13 +28,19 @@ constructor() : Application.ActivityLifecycleCallbacks {
         }
     }
 
-    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+    override fun onActivityCreated(
+        activity: Activity,
+        savedInstanceState: Bundle?,
+    ) = Unit
 
     override fun onActivityStarted(activity: Activity) = Unit
 
     override fun onActivityStopped(activity: Activity) = Unit
 
-    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+    override fun onActivitySaveInstanceState(
+        activity: Activity,
+        outState: Bundle,
+    ) = Unit
 
     override fun onActivityDestroyed(activity: Activity) = Unit
 }

--- a/data/src/main/java/com/teamyg/parfait/data/utils/CurrentActivityHolder.kt
+++ b/data/src/main/java/com/teamyg/parfait/data/utils/CurrentActivityHolder.kt
@@ -1,0 +1,40 @@
+package com.teamyg.parfait.data.utils
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import java.lang.ref.WeakReference
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * 현재 resumed 상태인 Activity 를 약한 참조로 보관
+ */
+@Singleton
+class CurrentActivityHolder
+@Inject
+constructor() : Application.ActivityLifecycleCallbacks {
+    private var currentActivity: WeakReference<Activity>? = null
+
+    fun current(): Activity? = currentActivity?.get()
+
+    override fun onActivityResumed(activity: Activity) {
+        currentActivity = WeakReference(activity)
+    }
+
+    override fun onActivityPaused(activity: Activity) {
+        if (currentActivity?.get() === activity) {
+            currentActivity = null
+        }
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+
+    override fun onActivityStarted(activity: Activity) = Unit
+
+    override fun onActivityStopped(activity: Activity) = Unit
+
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+
+    override fun onActivityDestroyed(activity: Activity) = Unit
+}


### PR DESCRIPTION
## 📌 Summary (필수)
<!-- 이 PR에서 무엇을 왜 변경했는지 간략히 설명해주세요 -->
- 웹페이지 카카오톡 로그인으로 이동되는 현상을 수정했습니다.

---

## ✅ Checklist (필수)
- [x] 셀프 코드 리뷰 완료
- [x] 코드 컨벤션 확인 완료
- [ ] UI 변경 시 스크린샷 첨부
- [ ] 관련 테스트 추가 / 수정
- [x] 로컬 테스트 통과
- [x] 머지 대상 브랜치 확인 (`develop` / `main` / 기타)

---

## 🔗 Related Issue (선택)
Closes #이슈번호

---

## 📱 Screenshots / Screen Recording (선택)
<!-- UI 변경이 있을 경우 Before / After 스크린샷 또는 GIF를 첨부해주세요 -->

| Before | After |
|--------|-------|
|        |       |

---

## 💬 Notes for Reviewer (선택)
<!-- 리뷰어가 특히 집중해서 봐야 할 부분이나 참고사항 -->
기존에 하기 오류 발생
`Failure(throwable=android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?)`

---

## 🧪 How to Test (선택)
<!-- 리뷰어가 재현할 수 있도록 테스트 방법을 적어주세요 -->
1.
2.
3. 
